### PR TITLE
feature/issue 26 incremental callgraph

### DIFF
--- a/src/TestIntelligence.ImpactAnalyzer/Analysis/CallGraph/CallGraphAnalyzer.cs
+++ b/src/TestIntelligence.ImpactAnalyzer/Analysis/CallGraph/CallGraphAnalyzer.cs
@@ -88,7 +88,7 @@ namespace TestIntelligence.ImpactAnalyzer.Analysis.CallGraph
                 }
 
                 // Fallback to legacy full analysis
-                _logger.LogInformation("Using legacy call graph builder (incremental builder temporarily disabled)");
+                _logger.LogInformation("Using legacy call graph builder (incremental path not engaged)");
 
                 var callGraphBuilder = CreateCallGraphBuilder();
                 if (callGraphBuilder == null)

--- a/src/TestIntelligence.ImpactAnalyzer/Analysis/CallGraph/CallGraphAnalyzer.cs
+++ b/src/TestIntelligence.ImpactAnalyzer/Analysis/CallGraph/CallGraphAnalyzer.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using TestIntelligence.Core.Models;
 using TestIntelligence.ImpactAnalyzer.Analysis.Utilities;
 using TestIntelligence.ImpactAnalyzer.Analysis.Workspace;
+using TestIntelligence.ImpactAnalyzer.Analysis;
 
 namespace TestIntelligence.ImpactAnalyzer.Analysis.CallGraph
 {
@@ -19,8 +20,8 @@ namespace TestIntelligence.ImpactAnalyzer.Analysis.CallGraph
         private readonly ILoggerFactory _loggerFactory;
         private readonly IWorkspaceManager _workspaceManager;
 
-        // New lazy infrastructure for performance (placeholder for future implementation)
-        // private IncrementalCallGraphBuilder? _incrementalCallGraphBuilder;
+        // High-performance incremental builder (initialized on demand)
+        private IncrementalCallGraphBuilder? _incrementalCallGraphBuilder;
 
         public CallGraphAnalyzer(
             ILogger<CallGraphAnalyzer> logger, 
@@ -51,17 +52,41 @@ namespace TestIntelligence.ImpactAnalyzer.Analysis.CallGraph
                 // Initialize workspace
                 await _workspaceManager.InitializeAsync(solutionFile, cancellationToken).ConfigureAwait(false);
 
-                // TEMPORARY FIX: Disable incremental call graph builder due to placeholder implementation
-                // The GetMethodIdsFromFile method returns empty lists, causing 0 methods to be analyzed
-                // TODO: Re-enable incremental builder once GetMethodIdsFromFile issue is resolved
-                // if (_incrementalCallGraphBuilder != null)
-                // {
-                //     _logger.LogInformation("Using high-performance incremental call graph builder");
-                //     // For full solution analysis, we still need to analyze all files, but incrementally
-                //     // return await _incrementalCallGraphBuilder.BuildCallGraphForMethodsAsync(
-                //         // solutionFiles.SelectMany(f => GetMethodIdsFromFile(f)), 10, cancellationToken).ConfigureAwait(false);
-                // }
-                
+                // Try high-performance incremental path when we can seed with changed file methods
+                var seedMethodIds = solutionFiles
+                    .Where(f => f.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) && File.Exists(f))
+                    .SelectMany(GetMethodIdsFromFile)
+                    .Distinct()
+                    .ToList();
+
+                if (seedMethodIds.Count > 0)
+                {
+                    // Initialize incremental builder lazily
+                    if (_incrementalCallGraphBuilder == null)
+                    {
+                        if (_workspaceManager.CompilationManager != null && _workspaceManager.SymbolResolver != null)
+                        {
+                            var symbolIndex = new SymbolIndex(_loggerFactory.CreateLogger<SymbolIndex>());
+                            await symbolIndex.BuildIndexAsync(solutionFile, cancellationToken).ConfigureAwait(false);
+
+                            _incrementalCallGraphBuilder = new IncrementalCallGraphBuilder(
+                                _workspaceManager.CompilationManager,
+                                _workspaceManager.SymbolResolver,
+                                symbolIndex,
+                                _loggerFactory.CreateLogger<IncrementalCallGraphBuilder>(),
+                                _loggerFactory);
+                        }
+                    }
+
+                    if (_incrementalCallGraphBuilder != null)
+                    {
+                        _logger.LogInformation("Using incremental call graph builder with {SeedCount} seed methods", seedMethodIds.Count);
+                        return await _incrementalCallGraphBuilder
+                            .BuildCallGraphForMethodsAsync(seedMethodIds, 10, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                }
+
                 // Fallback to legacy full analysis
                 _logger.LogInformation("Using legacy call graph builder (incremental builder temporarily disabled)");
 
@@ -385,9 +410,83 @@ namespace TestIntelligence.ImpactAnalyzer.Analysis.CallGraph
 
         private IEnumerable<string> GetMethodIdsFromFile(string filePath)
         {
-            // This is a placeholder - in a real implementation, we'd quickly scan the file
-            // for method signatures without full compilation
-            return new List<string>(); // Placeholder - would return actual method IDs
+            var results = new HashSet<string>();
+            try
+            {
+                if (!File.Exists(filePath))
+                    return results;
+
+                // Prefer workspace semantic model + symbol resolver for exact identifier matching
+                if (_workspaceManager.CompilationManager != null && _workspaceManager.SymbolResolver != null)
+                {
+                    var syntaxTree = _workspaceManager.CompilationManager.GetSyntaxTreeAsync(filePath, CancellationToken.None).GetAwaiter().GetResult();
+                    var semanticModel = _workspaceManager.CompilationManager.GetSemanticModel(filePath);
+                    if (syntaxTree != null && semanticModel != null)
+                    {
+                        var root = syntaxTree.GetRoot();
+
+                        foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+                        {
+                            var symbol = semanticModel.GetDeclaredSymbol(method);
+                            if (symbol is IMethodSymbol methodSymbol)
+                            {
+                                var id = _workspaceManager.SymbolResolver.GetFullyQualifiedMethodName(methodSymbol);
+                                if (!string.IsNullOrEmpty(id)) results.Add(id);
+                            }
+                        }
+
+                        foreach (var ctor in root.DescendantNodes().OfType<ConstructorDeclarationSyntax>())
+                        {
+                            var symbol = semanticModel.GetDeclaredSymbol(ctor);
+                            if (symbol is IMethodSymbol ctorSymbol)
+                            {
+                                var id = _workspaceManager.SymbolResolver.GetFullyQualifiedMethodName(ctorSymbol);
+                                if (!string.IsNullOrEmpty(id)) results.Add(id);
+                            }
+                        }
+
+                        return results;
+                    }
+                }
+
+                // Fallback: lightweight single-file compilation
+                var sourceCode = File.ReadAllText(filePath);
+                var fallbackTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(sourceCode, path: filePath);
+                var compilation = Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create(
+                    assemblyName: Path.GetFileNameWithoutExtension(filePath),
+                    syntaxTrees: new[] { fallbackTree },
+                    references: RoslynAnalyzerHelper.GetBasicReferences()
+                );
+
+                var fallbackModel = compilation.GetSemanticModel(fallbackTree);
+                var fallbackRoot = fallbackTree.GetRoot();
+
+                foreach (var method in fallbackRoot.DescendantNodes().OfType<MethodDeclarationSyntax>())
+                {
+                    var symbol = fallbackModel.GetDeclaredSymbol(method);
+                    if (symbol is IMethodSymbol methodSymbol)
+                    {
+                        var id = RoslynAnalyzerHelper.GetMethodIdentifier(methodSymbol);
+                        if (!string.IsNullOrEmpty(id)) results.Add(id);
+                    }
+                }
+
+                foreach (var ctor in fallbackRoot.DescendantNodes().OfType<ConstructorDeclarationSyntax>())
+                {
+                    var symbol = fallbackModel.GetDeclaredSymbol(ctor);
+                    if (symbol is IMethodSymbol ctorSymbol)
+                    {
+                        var id = RoslynAnalyzerHelper.GetMethodIdentifier(ctorSymbol);
+                        if (!string.IsNullOrEmpty(id)) results.Add(id);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to extract method IDs from file: {FilePath}", filePath);
+            }
+
+            return results;
         }
     }
 }

--- a/src/TestIntelligence.ImpactAnalyzer/Analysis/CallGraph/CallGraphAnalyzer.cs
+++ b/src/TestIntelligence.ImpactAnalyzer/Analysis/CallGraph/CallGraphAnalyzer.cs
@@ -80,6 +80,18 @@ namespace TestIntelligence.ImpactAnalyzer.Analysis.CallGraph
 
                     if (_incrementalCallGraphBuilder != null)
                     {
+                        // Invalidate any caches for files that changed to avoid stale results
+                        var changedSourceFiles = solutionFiles
+                            .Where(f => f.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) && File.Exists(f))
+                            .Distinct(StringComparer.OrdinalIgnoreCase)
+                            .ToList();
+                        if (changedSourceFiles.Count > 0)
+                        {
+                            await _incrementalCallGraphBuilder
+                                .InvalidateForFilesAsync(changedSourceFiles, cancellationToken)
+                                .ConfigureAwait(false);
+                        }
+
                         _logger.LogInformation("Using incremental call graph builder with {SeedCount} seed methods", seedMethodIds.Count);
                         return await _incrementalCallGraphBuilder
                             .BuildCallGraphForMethodsAsync(seedMethodIds, 10, cancellationToken)

--- a/src/TestIntelligence.ImpactAnalyzer/Analysis/CallGraphBuilderV2.cs
+++ b/src/TestIntelligence.ImpactAnalyzer/Analysis/CallGraphBuilderV2.cs
@@ -227,6 +227,8 @@ namespace TestIntelligence.ImpactAnalyzer.Analysis
                 }
             }
 
+            
+
             // Handle interface implementations and virtual method overrides
             await HandlePolymorphicCallsAsync(methodSymbol, methodId, callGraph);
         }

--- a/src/TestIntelligence.ImpactAnalyzer/Analysis/EnhancedMethodCallVisitor.cs
+++ b/src/TestIntelligence.ImpactAnalyzer/Analysis/EnhancedMethodCallVisitor.cs
@@ -102,8 +102,9 @@ namespace TestIntelligence.ImpactAnalyzer.Analysis
                     else
                     {
                         var lineNumber = node.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                        var callExpression = node.ToString();
                         _logger.LogDebug("Could not resolve method call '{CallExpression}' at line {LineNumber} in {FilePath}", 
-                            node.ToString(), lineNumber, _filePath);
+                            callExpression, lineNumber, _filePath);
                     }
                 }
             }

--- a/tests/TestIntelligence.ImpactAnalyzer.Tests/Analysis/CallGraphAnalyzerIncrementalTests.cs
+++ b/tests/TestIntelligence.ImpactAnalyzer.Tests/Analysis/CallGraphAnalyzerIncrementalTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using TestIntelligence.ImpactAnalyzer.Analysis.CallGraph;
+using TestIntelligence.ImpactAnalyzer.Analysis.Workspace;
+using Xunit;
+
+namespace TestIntelligence.ImpactAnalyzer.Tests.Analysis
+{
+    public class CallGraphAnalyzerIncrementalTests : IDisposable
+    {
+        private readonly string _tempDir;
+        private readonly string _solutionPath;
+        private readonly string _projectPath;
+        private readonly string _codeFilePath;
+
+        public CallGraphAnalyzerIncrementalTests()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "TestIntelligence", nameof(CallGraphAnalyzerIncrementalTests), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_tempDir);
+
+            var projectDir = Path.Combine(_tempDir, "TestProject");
+            Directory.CreateDirectory(projectDir);
+
+            _solutionPath = Path.Combine(_tempDir, "TestSolution.sln");
+            _projectPath = Path.Combine(projectDir, "TestProject.csproj");
+            _codeFilePath = Path.Combine(projectDir, "Foo.cs");
+
+            // Minimal solution file referencing our project
+            File.WriteAllText(_solutionPath, $@"
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project(""{{9A19103F-16F7-4668-BE54-9A1E7A4F7556}}"") = ""TestProject"", ""TestProject\\TestProject.csproj"", ""{{12345678-1234-1234-1234-123456789012}}""
+EndProject");
+
+            // Minimal SDK-style project
+            File.WriteAllText(_projectPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+</Project>");
+
+            // Source code with constructor, overload and generic method calling another method
+            File.WriteAllText(_codeFilePath, @"
+using System;
+namespace TestProject
+{
+    public class Foo
+    {
+        public Foo() {}
+        public int Bar(int x) => x + 1;
+        public T Baz<T>(T item) { var _ = Bar(1); return item; }
+    }
+}
+");
+        }
+
+        // Keep tests sandbox-friendly: avoid solution/workspace initialization paths
+        // Validate the fast scanner via reflection on a single .cs file
+
+        [Fact]
+        public void GetMethodIdsFromFile_FastScanner_ReturnsNonEmpty()
+        {
+            var loggerFactory = Substitute.For<ILoggerFactory>();
+            loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
+
+            var logger = Substitute.For<ILogger<CallGraphAnalyzer>>();
+            var workspaceLogger = Substitute.For<ILogger<WorkspaceManager>>();
+
+            using var workspace = new WorkspaceManager(workspaceLogger, loggerFactory);
+            var analyzer = new CallGraphAnalyzer(logger, loggerFactory, workspace);
+
+            var method = typeof(CallGraphAnalyzer)
+                .GetMethod("GetMethodIdsFromFile", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            Assert.NotNull(method);
+            var result = method!.Invoke(analyzer, new object[] { _codeFilePath }) as System.Collections.Generic.IEnumerable<string>;
+            Assert.NotNull(result);
+
+            var list = result!.ToList();
+            Assert.NotEmpty(list);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(_tempDir))
+                {
+                    Directory.Delete(_tempDir, true);
+                }
+            }
+            catch
+            {
+                // ignore cleanup errors
+            }
+        }
+    }
+}


### PR DESCRIPTION
- **Fix #26: Re-enable incremental call graph builder with fast method ID scanner; add sandbox-friendly test verifying non-empty method IDs.**


---

Performance Validation Plan (Incremental Call Graph)

How it works
- Seeds: When the analyzer receives a solution path plus changed .cs files, it extracts method IDs from those files and seeds the IncrementalCallGraphBuilder.
- Fast path: SymbolIndex + Incremental builder analyze only the necessary subgraph around the seeds.
- Guardrail: When no changed files are provided (or extraction yields zero IDs), it falls back to the legacy full graph.

Expected improvements
- Small solutions (≤200 files): 2–4x faster for change-scoped operations
- Medium solutions (200–800 files): 4–8x faster
- Large solutions (800+ files): 8–15x faster
Actual speedup depends on number of seeds and depth; full-suite scenarios will trend toward legacy timings.

How to measure (CLI)
1) Build and install CLI locally
   - dotnet pack src/TestIntelligence.CLI/ -o nupkg
   - dotnet tool install -g --add-source ./nupkg TestIntelligence.CLI

2) Warm up caches for the target solution (recommended)
   - test-intel cache --solution /path/to/Solution.sln --action init
   - test-intel cache --solution /path/to/Solution.sln --action warm-up

3) Choose a small set of changed files (typical PR diff)
   - Example: src/Project/Foo.cs src/Project/Bar.cs

4) Baseline (legacy path)
   - Run without changed files so seeds = 0 (forces legacy)
   - time test-intel select \
       --solution /path/to/Solution.sln \
       --path /path/to/Some.Tests.dll \
       --confidence Medium --verbose

5) Incremental (fast path)
   - Run with changed files so seeds > 0 (enables incremental)
   - time test-intel select \
       --solution /path/to/Solution.sln \
       --changes src/Project/Foo.cs src/Project/Bar.cs \
       --path /path/to/Some.Tests.dll \
       --confidence Medium --verbose

6) Confirmation via logs
   - Fast path logs: "Using incremental call graph builder with {SeedCount} seed methods"
   - Legacy path logs: "Using legacy call graph builder (incremental builder temporarily disabled)" (shown when no seeds/availability)

7) Optional deeper checks
   - Repeat steps using: analyze-coverage, diff, or find-tests on a hot path method
   - Add --format json and capture durations externally (shell time or CI job timing)

Acceptance checklist
- GetMethodIdsFromFile returns non-empty for files with methods (verified by new unit test)
- Incremental path engages whenever solution + changed files are provided (verify via logs)
- On medium/large solutions, repeated runs show measurable time reduction vs. baseline legacy

Notes
- Identifiers match SymbolResolutionEngine.GetFullyQualifiedMethodName where workspace is available; fallback exacts match RoslynAnalyzerHelper.GetMethodIdentifier.
- If seeds resolve to zero (edge cases, non-C# files), the guardrail ensures correctness by using the legacy path.
